### PR TITLE
[#10] React front end treats numbers entered as strings

### DIFF
--- a/app/javascript/react/components/AddStatsForm/AddStatsForm.js
+++ b/app/javascript/react/components/AddStatsForm/AddStatsForm.js
@@ -1,7 +1,7 @@
+/* eslint-disable react/no-array-index-key */
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { gql, useQuery } from "@apollo/client";
-import uuid from "react-uuid";
 import FormInput from "../FormInput/FormInput";
 import { changeObjectToArray } from "../../../utility/convertArrayAndObject";
 

--- a/app/javascript/react/components/FormInput/FormInput.js
+++ b/app/javascript/react/components/FormInput/FormInput.js
@@ -58,7 +58,10 @@ const FormInput = ({
 );
 
 FormInput.propTypes = {
-  formInput: PropTypes.object.isRequired,
+  formInput: PropTypes.shape({
+    activity: PropTypes.string,
+    answer: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  }).isRequired,
   inputChangeHandler: PropTypes.func.isRequired,
   addFormInput: PropTypes.func.isRequired,
   removeFormInput: PropTypes.func.isRequired,

--- a/app/javascript/react/components/TextField/TextField.js
+++ b/app/javascript/react/components/TextField/TextField.js
@@ -22,7 +22,10 @@ const TextField = ({
 TextField.propTypes = {
   type: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.number.isRequired,
+  ]).isRequired,
   className: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
   inputChangeHandler: PropTypes.func.isRequired,

--- a/app/javascript/utility/convertArrayAndObject.js
+++ b/app/javascript/utility/convertArrayAndObject.js
@@ -1,8 +1,10 @@
 const changeArrayToObject = (array) => {
   const obj = {};
-  array.forEach(({ activity, answer }) => {
-    obj[activity] = answer;
-  });
+  array
+    .filter((item) => item.activity !== "" || item.answer !== "")
+    .forEach(({ activity, answer }) => {
+      obj[activity] = parseFloat(answer, 10);
+    });
   return obj;
 };
 

--- a/spec/features/user_adds_stats_using_nice_ui_spec.rb
+++ b/spec/features/user_adds_stats_using_nice_ui_spec.rb
@@ -63,7 +63,6 @@ feature "User adds stats using nice UI", js: true do
       Then "she sees the new stat visible as well" do
         page.find("nav a", text: "admin").click
         page.find("nav.navigation a", text: "Daily Stats").click
-        pending "the React UI saving numeric data not string"
         expect(
           page
             .find_all("table tr td")

--- a/spec/support/page_fragments.rb
+++ b/spec/support/page_fragments.rb
@@ -7,11 +7,11 @@ module PageFragments
     require File.join(args.map(&:to_s))
     page = Page.new self
     page_fragment = args
-      .map(&:to_s)
-      .map(&:camelize)
-      .reduce(PageFragments) do |module_name, part|
-      module_name.const_get(part, false)
-    end
+                    .map(&:to_s)
+                    .map(&:camelize)
+                    .reduce(PageFragments) do |module_name, part|
+                      module_name.const_get(part, false)
+                    end
     page = page.extend(page_fragment)
     yield page if block_given?
     page


### PR DESCRIPTION
convertArrayAndObject.js:
Exclude empty form fields and ensure stats answer is sent to server as numeric values rather than strings.
AddStatsForm.js:
At file level, ignoring an eslint rule that considers using `index` as a key to be invalid:
there is no `id` on objects at that point, so using `index` should be allowed.
Removing unused UUID import from AddStatsForm
FormInput.js and TextField.js:
Tweaks to accepted data types for input fields - now allowing numbers as well as text. Not currently used. This is for future-proofing.
Making test not "pending" and formatting according to rubocop's policy in page_fragments.