### PR TITLE
Tests/add factory bot

### DIFF
--- a/app/javascript/react/components/AddStatsForm/AddStatsForm.js
+++ b/app/javascript/react/components/AddStatsForm/AddStatsForm.js
@@ -1,7 +1,7 @@
+/* eslint-disable react/no-array-index-key */
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { gql, useQuery } from "@apollo/client";
-import uuid from "react-uuid";
 import FormInput from "../FormInput/FormInput";
 import { changeObjectToArray } from "../../../utility/convertArrayAndObject";
 

--- a/app/javascript/react/components/FormInput/FormInput.js
+++ b/app/javascript/react/components/FormInput/FormInput.js
@@ -58,7 +58,10 @@ const FormInput = ({
 );
 
 FormInput.propTypes = {
-  formInput: PropTypes.object.isRequired,
+  formInput: PropTypes.shape({
+    activity: PropTypes.string,
+    answer: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  }).isRequired,
   inputChangeHandler: PropTypes.func.isRequired,
   addFormInput: PropTypes.func.isRequired,
   removeFormInput: PropTypes.func.isRequired,

--- a/app/javascript/react/components/TextField/TextField.js
+++ b/app/javascript/react/components/TextField/TextField.js
@@ -22,7 +22,10 @@ const TextField = ({
 TextField.propTypes = {
   type: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.number.isRequired,
+  ]).isRequired,
   className: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
   inputChangeHandler: PropTypes.func.isRequired,

--- a/app/javascript/utility/convertArrayAndObject.js
+++ b/app/javascript/utility/convertArrayAndObject.js
@@ -1,8 +1,10 @@
 const changeArrayToObject = (array) => {
   const obj = {};
-  array.forEach(({ activity, answer }) => {
-    obj[activity] = answer;
-  });
+  array
+    .filter((item) => item.activity !== "" || item.answer !== "")
+    .forEach(({ activity, answer }) => {
+      obj[activity] = parseFloat(answer, 10);
+    });
   return obj;
 };
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,4 +64,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.factory_bot.definition_file_paths = ["spec/support/factories"]
 end

--- a/spec/features/user_adds_stats_using_nice_ui_spec.rb
+++ b/spec/features/user_adds_stats_using_nice_ui_spec.rb
@@ -1,27 +1,11 @@
 require "rails_helper"
 
 feature "User adds stats using nice UI", js: true do
-  context "A user existst with stats" do
+  context "A user exists with stats" do
     before do
-      @user_claudia = User.create!(
-        email: "claudia.king@automio.com",
-        password: "1password",
-        confirmed_at: DateTime.now,
-      )
-      @user_claudia.daily_stats.create!(
-        date: Date.parse("2015-04-01"),
-        data: {
-          weight: 66.6,
-          situps: 100,
-        },
-      )
-      @user_claudia.daily_stats.create!(
-        date: Date.parse("2015-04-02"),
-        data: {
-          weight: 66.6,
-          situps: 80,
-        },
-      )
+      @user_claudia = create(:user_claudia)
+      @user_claudia.daily_stats.append(create(:daily_stat, date: Date.parse("2015-04-01"), data: { situps: 100, weight: 66.6 }, user: @user_claudia))
+      @user_claudia.daily_stats.append(create(:daily_stat, date: Date.parse("2015-04-02"), data: { situps: 80, weight: 66.6 }, user: @user_claudia))
     end
 
     scenario "Claudia signs in, sees her stats and updates them" do

--- a/spec/features/user_adds_stats_using_nice_ui_spec.rb
+++ b/spec/features/user_adds_stats_using_nice_ui_spec.rb
@@ -47,7 +47,6 @@ feature "User adds stats using nice UI", js: true do
       Then "she sees the new stat visible as well" do
         page.find("nav a", text: "admin").click
         page.find("nav.navigation a", text: "Daily Stats").click
-        pending "the React UI saving numeric data not string"
         expect(
           page
             .find_all("table tr td")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,7 +40,7 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include FactoryBot::Syntax::Methods
-  
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,7 @@ require "capybara/email/rspec"
 $LOAD_PATH << Rails.root.join("spec/support/page_fragments")
 Dir[
   Rails.root.join(File.join("spec", "support", "**", "*.rb"))
-].reject { |f| f.include?("page_fragments/") }
+].reject { |f| f.include?("page_fragments/") || f.include?("factories/") }
   .each { |f| require f }
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -39,7 +39,8 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
+  config.include FactoryBot::Syntax::Methods
+  
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/support/factories/daily_stat.rb
+++ b/spec/support/factories/daily_stat.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :daily_stat do
+    id { |index| index }
+    date { DateTime.now - rand(0...1460)}
+    data { { weight: 66.0 + rand(0.0...3.0), situps: 80 + rand(0...10) } }
+  end
+end

--- a/spec/support/factories/daily_stat.rb
+++ b/spec/support/factories/daily_stat.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :daily_stat do
     id { |index| index }
-    date { DateTime.now - rand(0...1460)}
-    data { { weight: 66.0 + rand(0.0...3.0), situps: 80 + rand(0...10) } }
+    date { DateTime.now - rand(0...1460) }
+    data { { weight: 66.0 + rand(0.0...3.0), situps: rand(70...100) } }
   end
 end

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :user do
     id { |index| index }
     factory :user_claudia do
-      email {|index| "claudia.king@automio.com"}
+      email { "claudia.king@automio.com" }
       password { "1password" }
       confirmed_at { DateTime.now }
     end
-    
+
     factory :user_with_daily_stats do
       transient do
         posts_count { 5 }

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :user do
+    id { |index| index }
+    factory :user_claudia do
+      email {|index| "claudia.king@automio.com"}
+      password { "1password" }
+      confirmed_at { DateTime.now }
+    end
+    
+    factory :user_with_daily_stats do
+      transient do
+        posts_count { 5 }
+      end
+
+      daily_stats do
+        Array.new(posts_count) { association(:daily_stat) }
+      end
+    end
+  end
+end

--- a/spec/support/page_fragments.rb
+++ b/spec/support/page_fragments.rb
@@ -7,11 +7,11 @@ module PageFragments
     require File.join(args.map(&:to_s))
     page = Page.new self
     page_fragment = args
-      .map(&:to_s)
-      .map(&:camelize)
-      .reduce(PageFragments) do |module_name, part|
-      module_name.const_get(part, false)
-    end
+                    .map(&:to_s)
+                    .map(&:camelize)
+                    .reduce(PageFragments) do |module_name, part|
+                      module_name.const_get(part, false)
+                    end
     page = page.extend(page_fragment)
     yield page if block_given?
     page


### PR DESCRIPTION
This includes fixes from issue/reactTreatsNumbersAsStrings. 

convertArrayAndObject.js:
Exclude empty form fields and ensure stats answer is sent to server as numeric values rather than strings.
AddStatsForm.js:
At file level, ignoring an eslint rule that considers using index as a key to be invalid:
there is no id on objects at that point, so using index should be allowed.
Removing unused UUID import from AddStatsForm
FormInput.js and TextField.js:
Tweaks to accepted data types for input fields - now allowing numbers as well as text. Not currently used. This is for future-proofing.
Making test not "pending" and formatting according to rubocop's policy in page_fragments.

Also adding Factory Bot to our testing Suite. Using Factory Bot to create a user in tests. 